### PR TITLE
Replace purple framer artificers with light blue, add more nature inspired branding

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,9 @@
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
     --radius: 0.5rem;
+    --nature-green: 120 40% 30%;
+    --nature-brown: 30 20% 50%;
+    --nature-sky: 200 70% 80%;
   }
 }
 

--- a/src/components/action-button.tsx
+++ b/src/components/action-button.tsx
@@ -1,10 +1,10 @@
 export function ActionButton({label}: {label: string}) {
     return (
-        <button className={"relative py-2 px-3 rounded-lg font-medium text-sm bg-gradient-to-b from-[#f5f5dc] to-[#228b22] shadow-[0px_0px_12px_#8c45ff]"}>
+        <button className={"relative py-2 px-3 rounded-lg font-medium text-sm bg-gradient-to-b from-[#f5f5dc] to-[#228b22] shadow-[0px_0px_12px_#0000FF]"}>
             <div className={"absolute inset-0 rounded-lg"}>
                 <div className={"absolute inset-0 border rounded-lg border-white/20 [mask-image:linear-gradient(to_bottom,black,transparent)]"}/>
                 <div className={"absolute inset-0 border rounded-lg border-white/40 [mask-image:linear-gradient(to_top,black,transparent)]"}/>
-                <div className={"absolute inset-0 rounded-lg shadow-[0_0_10px_rgb(140,69,255,0.7)_inset]"}/>
+                <div className={"absolute inset-0 rounded-lg shadow-[0_0_10px_rgb(0,0,255,0.7)_inset]"}/>
             </div>
             <span>{label}</span>
         </button>

--- a/src/components/call-to-action.tsx
+++ b/src/components/call-to-action.tsx
@@ -44,9 +44,9 @@ export function CallToAction() {
                         transition={{duration: 120, repeat: Infinity, ease: 'linear'}}
                         className={"border border-muted py-24 px-6 rounded-xl overflow-hidden relative group"}
                         style={{backgroundImage: `url(${BackgroundStars.src})`, backgroundPositionY}}>
-                        <div className={"absolute inset-0 bg-[rgb(74,32,138)] bg-blend-overlay [mask-image:radial-gradient(50%_50%_at_50%_35%,black,transparent)] group-hover:opacity-0 transition duration-700"} style={{backgroundImage: `url(${BackgroundGrid.src})`}}/>
+                        <div className={"absolute inset-0 bg-[rgb(0,0,255)] bg-blend-overlay [mask-image:radial-gradient(50%_50%_at_50%_35%,black,transparent)] group-hover:opacity-0 transition duration-700"} style={{backgroundImage: `url(${BackgroundGrid.src})`}}/>
                         <motion.div
-                            className={"absolute inset-0 bg-[rgb(74,32,138)] bg-blend-overlay opacity-0 group-hover:opacity-100 transition duration-700"}
+                            className={"absolute inset-0 bg-[rgb(0,0,255)] bg-blend-overlay opacity-0 group-hover:opacity-100 transition duration-700"}
                             style={{backgroundImage: `url(${BackgroundGrid.src})`, maskImage: maskImage}} ref={borderedDivRef}/>
                         <div className={"relative"}>
                             <h2 className={"text-5xl tracking-tighter text-center font-medium"}>

--- a/src/components/testimonials.tsx
+++ b/src/components/testimonials.tsx
@@ -53,11 +53,11 @@ export function Testimonials() {
                             className={"flex flex-none gap-5"}>
                             {[...testimonials ,...testimonials].map((testimonial, index) => (
                                 <div key={index}
-                                     className={"border border-muted p-6 md:p-10 rounded-xl bg-[linear-gradient(to_bottom_left,rgb(140,69,255,0.3),black)] max-w-xs md:max-w-md flex-none"}>
+                                     className={"border border-muted p-6 md:p-10 rounded-xl bg-[linear-gradient(to_bottom_left,rgb(0,0,255,0.3),black)] max-w-xs md:max-w-md flex-none"}>
                                     <p className={"text-lg md:text-2xl tracking-tight"}>{testimonial.text}</p>
                                     <div className={"flex items-center gap-3 mt-5"}>
                                         <div
-                                            className={"relative after:content-[''] after:absolute after:inset-0 after:bg-[rgb(140,69,244)] after:mix-blend-soft-light after:rounded-lg before:content-[''] before:absolute before:inset-0 before:border before:border-white/30 before:z-10 before:rounded-lg"}>
+                                            className={"relative after:content-[''] after:absolute after:inset-0 after:bg-[rgb(0,0,255)] after:mix-blend-soft-light after:rounded-lg before:content-[''] before:absolute before:inset-0 before:border before:border-white/30 before:z-10 before:rounded-lg"}>
                                             <Image src={testimonial.avatarImg} alt={`${testimonial.name}`}
                                                    className={"size-11 rounded-lg grayscale"}/>
                                         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -60,6 +60,18 @@ const config = {
           DEFAULT: "hsl(120, 40%, 30%)",
           foreground: "hsl(30, 20%, 80%)",
         },
+        natureGreen: {
+          DEFAULT: "hsl(120, 40%, 30%)",
+          foreground: "hsl(30, 20%, 80%)",
+        },
+        natureBrown: {
+          DEFAULT: "hsl(30, 20%, 50%)",
+          foreground: "hsl(120, 40%, 30%)",
+        },
+        natureSky: {
+          DEFAULT: "hsl(200, 70%, 80%)",
+          foreground: "hsl(120, 40%, 30%)",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
Replace purple framer artificers with light blue and add nature-inspired branding.

* **Action Button Component**
  - Replace purple framer artificers color `#8c45ff` with light blue color `#0000FF`.
  - Replace shadow color `rgb(140,69,255,0.7)` with `rgb(0,0,255,0.7)`.

* **Call to Action Component**
  - Replace purple framer artificers color `rgb(74,32,138)` with light blue color `rgb(0,0,255)`.

* **Testimonials Component**
  - Replace purple framer artificers color `rgb(140,69,255,0.3)` with light blue color `rgb(0,0,255,0.3)`.
  - Replace background color `rgb(140,69,244)` with `rgb(0,0,255)`.

* **Global CSS**
  - Add nature-inspired colors `--nature-green`, `--nature-brown`, and `--nature-sky`.

* **Tailwind Configuration**
  - Add nature-inspired colors `natureGreen`, `natureBrown`, and `natureSky`.

