### PR TITLE
Add buttons underneath pricing options

### DIFF
--- a/src/components/pricing-section.tsx
+++ b/src/components/pricing-section.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ActionButton } from '@/components/action-button';
 
 const pricingTiers = [
    {
@@ -40,6 +41,9 @@ export function PricingSection() {
                   </li>
                 ))}
               </ul>
+              <div className="mt-4">
+                <ActionButton label={`${tier.price} - ${tier.title}`} />
+              </div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
Add buttons underneath pricing options in `PricingSection` component.

* Import `ActionButton` component from `@/components/action-button`.
* Add `ActionButton` component underneath each pricing option, displaying the price and type.
* Make the `ActionButton` component clickable.

