### PR TITLE
Add GIF player for product previews

### DIFF
--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import {DotLottieCommonPlayer, DotLottiePlayer,} from "@dotlottie/react-player";
+import GifPlayer from "./gif-player";
 import ProductImage from "@/assets/product-image.png";
 import {animate, motion, useMotionTemplate, useMotionValue, ValueAnimationTransition,} from "framer-motion";
 import {ComponentPropsWithoutRef, useEffect, useRef, useState} from "react";
 
 const tabs = [
     {
-        icon: "/assets/lottie/vroom.lottie",
+        icon: "/assets/gifs/resolution-search.gif",
         title: "Resolution Search",
         isNew: false,
         backgroundPositionX: 0,
@@ -15,7 +15,7 @@ const tabs = [
         backgroundSizeX: 150,
     },
     {
-        icon: "/assets/lottie/click.lottie",
+        icon: "/assets/gifs/advanced-visualization.gif",
         title: "Advanced Visualization Tools",
         isNew: false,
         backgroundPositionX: 98,
@@ -23,7 +23,7 @@ const tabs = [
         backgroundSizeX: 135,
     },
     {
-        icon: "/assets/lottie/stars.lottie",
+        icon: "/assets/gifs/location-intelligence.gif",
         title: "Location Intelligence",
         isNew: true,
         backgroundPositionX: 100,
@@ -37,7 +37,7 @@ const FeatureTab = (
         ComponentPropsWithoutRef<"div"> & { selected: boolean }
 ) => {
     const tabRef = useRef<HTMLDivElement>(null);
-    const dotLottieRef = useRef<DotLottieCommonPlayer>(null);
+    const gifRef = useRef<HTMLImageElement>(null);
 
     const xPercentage = useMotionValue(0);
     const yPercentage = useMotionValue(0);
@@ -72,9 +72,8 @@ const FeatureTab = (
     }, [props.selected]);
 
     const handleTabHover = () => {
-        if (dotLottieRef.current === null) return;
-        dotLottieRef.current.seek(0);
-        dotLottieRef.current.play();
+        if (gifRef.current === null) return;
+        gifRef.current.src = props.icon;
     };
 
     return (
@@ -96,11 +95,10 @@ const FeatureTab = (
             )}
 
             <div className={"size-12 border border-muted rounded-lg inline-flex items-center justify-center"}>
-                <DotLottiePlayer
+                <GifPlayer
                     src={props.icon}
-                    className={"size-5"}
-                    autoplay
-                    ref={dotLottieRef}
+                    alt={props.title}
+                    ref={gifRef}
                 />
             </div>
             <div className={"font-medium"}>{props.title}</div>

--- a/src/components/gif-player.tsx
+++ b/src/components/gif-player.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useRef } from 'react';
+
+const GifPlayer = ({ src, alt }) => {
+  const gifRef = useRef(null);
+
+  useEffect(() => {
+    const gifElement = gifRef.current;
+
+    const handleMouseEnter = () => {
+      gifElement.src = src;
+    };
+
+    const handleMouseLeave = () => {
+      gifElement.src = '';
+    };
+
+    gifElement.addEventListener('mouseenter', handleMouseEnter);
+    gifElement.addEventListener('mouseleave', handleMouseLeave);
+
+    return () => {
+      gifElement.removeEventListener('mouseenter', handleMouseEnter);
+      gifElement.removeEventListener('mouseleave', handleMouseLeave);
+    };
+  }, [src]);
+
+  return <img ref={gifRef} alt={alt} />;
+};
+
+export default GifPlayer;


### PR DESCRIPTION
Add a GIF player to preview different product scenes for various options.

* Create a new `GifPlayer` component in `src/components/gif-player.tsx` to handle GIF playing on hover.
* Modify `src/components/features.tsx` to import and use the new `GifPlayer` component.
* Replace Lottie animations with GIFs for product previews in the `tabs` array.
* Add GIFs for advanced visualization, location intelligence, and resolution search in `public/assets/gifs/`.

