### PR TITLE
Add privacy and terms link and page

### DIFF
--- a/src/app/privacy-terms.tsx
+++ b/src/app/privacy-terms.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+
+const PrivacyTerms = () => {
+  return (
+    <div className="container mx-auto py-10">
+      <h1 className="text-3xl font-bold mb-6">Privacy and Terms</h1>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Privacy Policy for Queue Enterprise (QCX)</h2>
+        <p>
+          At Queue Enterprise (QCX), your privacy is a priority. Our Privacy Policy details what information we collect and how we use it.
+        </p>
+        <p>
+          If you have additional questions or require more information about our Privacy Policy, do not hesitate to contact us through email at admin@QCX.com
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">General Data Protection Regulation (GDPR)</h2>
+        <p>
+          We are a Data Controller of your information under the terms of the European General Data Protection Regulation. To better understand your rights under the GDPR, see this resource provided by the UK Information Commissioner's Office.
+        </p>
+        <p>
+          Queue Enterprise Inc. (hereafter "QCX", "we" or "us") legal basis for collecting and using the personal information described in this Privacy Policy depends on the Personal Information we collect and the specific context in which we collect the information:
+        </p>
+        <ul>
+          <li>We need to perform a contract with you</li>
+          <li>You have given us permission to do so</li>
+          <li>Processing your personal information is in our legitimate interests</li>
+          <li>We need to comply with the law</li>
+        </ul>
+        <p>
+          Queue Enterprise Inc. will retain your personal information only for as long as is necessary for the purposes set out in this Privacy Policy. We will retain and use your information to the extent necessary to comply with our legal obligations, resolve disputes, and enforce our policies.
+        </p>
+        <p>
+          If you are a resident of the European Economic Area (EEA), you have certain data protection rights. If you wish to be informed what Personal Information we hold about you and if you want it to be removed from our systems, please contact us.
+        </p>
+        <p>
+          In certain circumstances, you have the following data protection rights:
+        </p>
+        <ul>
+          <li>The right to access, update or to delete the information we have on you.</li>
+          <li>The right of rectification.</li>
+          <li>The right to object.</li>
+          <li>The right of restriction.</li>
+          <li>The right to data portability</li>
+          <li>The right to withdraw consent</li>
+        </ul>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Log Files</h2>
+        <p>
+        QCX follows a standard procedure of using log files. These files log visitors when they visit websites. All hosting companies do this and a part of hosting services' analytics. The information collected by log files include internet protocol (IP) addresses, browser type, Internet Service Provider (ISP), date and time stamp, referring/exit pages, and possibly the number of clicks. These are not linked to any information that is personally identifiable. The purpose of the information is for analyzing trends, administering the site, tracking users' movement on the website, and gathering demographic information.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Cookies and Web Beacons</h2>
+        <p>
+          Like any other website, QCX uses 'cookies'. These cookies are used to store information including visitors' preferences, and the pages on the website that the visitor accessed or visited. The information is used to optimize the users' experience by customizing our web page content based on visitors' browser type and/or other information.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">User-provided Information</h2>
+        <p>
+          To run QCX, we collect and process the following kinds of information.
+        </p>
+        <h3 className="text-xl font-semibold mb-2">Google data</h3>
+        <p>
+          If you choose to sign in with Google, we will receive your email and Google account ID to help us authenticate you when signing in, and for contacting you with product updates and account changes.
+        </p>
+        <h3 className="text-xl font-semibold mb-2">Gmail data</h3>
+        <p>
+          If you choose to connect your Gmail account to QCX, we will use access to your Gmail account to solely parse travel receipts. Specifically:
+        </p>
+        <ul>
+          <li>We will receive a notification from Gmail when you receive a new email.</li>
+          <li>We will parse the email with the help of OpenAI to identify whether it is a travel receipts (for hotels, flights, and other bookings).</li>
+          <li>If after parsing, we determine that the email is for travel, we will create a document on QCX with the confirmation and store the receipt on our servers. Otherwise, we'll delete any temporary data we have about the email.</li>
+          <li>We will not store or process any emails other than as outlined above.</li>
+        </ul>
+        <p>
+          QCX will never:
+        </p>
+        <ul>
+          <li>Use Gmail data for ad targeting or serving.</li>
+          <li>Allow any employees to read Gmail data unless we either 1) obtained your consent in writing; 2) need it for security purposes (bug investigation and abuse monitoring); or 3) are required to disclose it for legal purposes.</li>
+          <li>All internal uses not mentioned in item 2 above will be only of aggregated, anonymized Gmail data.</li>
+        </ul>
+        <p>
+          All uses of this data will also comply with the Google API Services: User Data Policy.
+        </p>
+        <h3 className="text-xl font-semibold mb-2">Facebook data</h3>
+        <p>
+          If you choose to sign in with Facebook, we will receive your basic profile information (your name, Facebook account ID) which we will use to authenticate you when signing in.
+        </p>
+        <p>
+          If you grant us permission to get your email address, we will also receive your email which we'll use to contact you with product updates.
+        </p>
+        <p>
+          If you grant us permission to see which of your friends also use QCX, we will use that information only to display a list of itineraries/trip plans and other contributions that your Facebook friends have created on QCX.
+        </p>
+        <h3 className="text-xl font-semibold mb-2">User profile data</h3>
+        <p>
+          You can also sign up for QCX using your email and a password. We will retain this information to authenticate you and occasionally contact you with product updates and account changes.
+        </p>
+        <p>
+          Once signed into QCX, you may set a username, display name, and home base location to display on your profile. This information will be used as a part of your public profile on QCX for readers to get to know you, and is associated with your posts.
+        </p>
+        <h3 className="text-xl font-semibold mb-2">Trip plan data</h3>
+        <p>
+          When using QCX, you may select places, write comments, Like specific places, and paste images/maps into your trip logs. This data will be stored and shown when someone views a trip log that you have authored.
+        </p>
+        <h3 className="text-xl font-semibold mb-2">Deleting your data</h3>
+        <p>
+          To delete your account and associated user data, you may sign in and visit our settings page, which includes a "Delete account" button. Our system will fully delete your account within two weeks of receiving the request.
+        </p>
+        <h3 className="text-xl font-semibold mb-2">Mobile phone number</h3>
+        <p>
+          You might provide your phone number to us so that we can send you a text message to download our app. This will only be used to send texts directly from us.
+        </p>
+        <p>
+          No phone numbers or mobile information will be shared with third parties/affiliates for marketing/promotional purposes. All the above categories exclude text messaging originator opt-in data and consent; this information will not be shared with any third parties.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Third Party Advertisers</h2>
+        <p>
+          Third-party ad servers or ad networks use technologies like cookies, JavaScript, or Web Beacons that are used in their respective advertisements and links that appear on QCX, which are sent directly to users' browser. They automatically receive your IP address when this occurs. These technologies are used to measure the effectiveness of their advertising campaigns and/or to personalize the advertising content that you see on websites that you visit.
+        </p>
+        <p>
+          Note that QCX has no access to or control over these cookies that are used by third-party advertisers.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Third Party Privacy Policies</h2>
+        <p>
+          QCX's Privacy Policy does not apply to other advertisers or websites. Thus, we are advising you to consult the respective Privacy Policies of these third-party ad servers for more detailed information. It may include their practices and instructions about how to opt-out of certain options.
+        </p>
+        <p>
+          You can choose to disable cookies through your individual browser options. To know more detailed information about cookie management with specific web browsers, it can be found at the browsers' respective websites.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Children's Information</h2>
+        <p>
+          Another part of our priority is adding protection for children while using the internet. We encourage parents and guardians to observe, participate in, and/or monitor and guide their online activity.
+        </p>
+        <p>
+          QCX does not knowingly collect any Personal Identifiable Information from children under the age of 13. If you think that your child provided this kind of information on our website, we strongly encourage you to contact us immediately and we will do our best efforts to promptly remove such information from our records.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Updates</h2>
+        <p>
+          While we strive to maintain a consistent Privacy Policy, we do update it from time to time. We may do this in some cases with limited or no notice.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Consent</h2>
+        <p>
+          By using our website or app, you hereby consent to our Privacy Policy and agree to its terms.
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default PrivacyTerms;

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -17,7 +17,9 @@ export default function SiteFooter() {
                         <p className={"font-medium italic"}>atlas</p>
                     </section>
 
-
+                    <Link href="/privacy-terms" className="text-sm text-muted-foreground hover:underline">
+                        Privacy and Terms
+                    </Link>
 
                     <p className="text-balance text-center text-sm leading-loose text-muted-foreground md:text-left">
                         ©️ 2024 QCX, All rights reserved. Built by <a


### PR DESCRIPTION
Add a privacy and terms link at the footer that navigates to a new page with a standard privacy and terms agreement for a US company that logs location data.

* **Footer Component**: Modify `src/components/site-footer.tsx` to include a "Privacy and Terms" link that navigates to `/privacy-terms`. Ensure the link uses the same font and color as other footer links.
* **Privacy and Terms Page**: Create a new file `src/app/privacy-terms.tsx` containing the privacy and terms agreement for Queue Enterprise (QCX). The page includes sections on GDPR, log files, cookies, user-provided information, third-party advertisers, third-party privacy policies, children's information, updates, and consent. Ensure the page uses the same font and color scheme as the main site.

