### PR TITLE
Embed social media links underneath logos in footer

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -17,8 +17,6 @@ export default function SiteFooter() {
                         <p className={"font-medium italic"}>atlas</p>
                     </section>
 
-
-
                     <p className="text-balance text-center text-sm leading-loose text-muted-foreground md:text-left">
                         ©️ 2024 QCX, All rights reserved. Built by <a
                         href={"https://github.com/queuelab/mapgpt"}
@@ -32,11 +30,24 @@ export default function SiteFooter() {
                     </p>
                     <div>
                         <ul className={"flex justify-center gap-3 text-white/40"}>
-                            <li className={"hover:text-white cursor-pointer"}><X/></li>
-                            <li className={"hover:text-white cursor-pointer"}><Instagram/></li>
-                            <li className={"hover:text-white cursor-pointer"}><Youtube/></li>
-                            <li className={"hover:text-white cursor-pointer"}><Link href="https://x.com/queue_cx">queue_cx</Link></li>
-                            <li className={"hover:text-white cursor-pointer"}><Link href="https://instagram.com/queue.lab">queue.lab</Link></li>
+                            <li className={"hover:text-white cursor-pointer"}>
+                                <div className={"flex flex-col items-center"}>
+                                    <X/>
+                                    <Link href="https://x.com/queue_cx">queue_cx</Link>
+                                </div>
+                            </li>
+                            <li className={"hover:text-white cursor-pointer"}>
+                                <div className={"flex flex-col items-center"}>
+                                    <Instagram/>
+                                    <Link href="https://instagram.com/queue.lab">queue.lab</Link>
+                                </div>
+                            </li>
+                            <li className={"hover:text-white cursor-pointer"}>
+                                <div className={"flex flex-col items-center"}>
+                                    <Youtube/>
+                                    <Link href="https://youtube.com/queue_cx">queue_cx</Link>
+                                </div>
+                            </li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
Embed the social media links underneath the logos in `src/components/site-footer.tsx`.

* Wrap each logo and its corresponding link in a `div` element.
* Adjust the CSS classes to ensure proper alignment and spacing.
* Remove the separate list items for the social media links and logos.
* Update the `ul` element to contain the new structure with embedded links and logos.

