### PR TITLE
Replace all occurrences of atlas with mapgpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ATLAS - AI-powered Earth Intelligence Platform
+# MAPGPT - AI-powered Earth Intelligence Platform
 
-ATLAS is an Earth intelligence platform developed by QCX part of queuelab. It leverages advanced generative artificial intelligence technology to provide real-time insights and analytics about our planet. Whether you're an explorer, traveler or researcher ATLAS offers a comprehensive suite of tools to help you explore, visualize and perform automation tasks. 
+MAPGPT is an Earth intelligence platform developed by QCX part of queuelab. It leverages advanced generative artificial intelligence technology to provide real-time insights and analytics about our planet. Whether you're an explorer, traveler or researcher MAPGPT offers a comprehensive suite of tools to help you explore, visualize and perform automation tasks. 
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "atlas-earth-intelligence",
+  "name": "mapgpt-earth-intelligence",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,8 +8,8 @@ const inter = Inter({ subsets: ["latin"] });
 const roboto = Roboto({ subsets: ["latin"], weight: ["400", "700"] });
 
 export const metadata: Metadata = {
-  title: "ATLAS",
-  description: "ATLAS - AI-powered Earth intelligence platform by QCX",
+  title: "MAPGPT",
+  description: "MAPGPT - AI-powered Earth intelligence platform by QCX",
 };
 
 export default function RootLayout({children,}: Readonly<{ children: React.ReactNode; }>) {

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -152,7 +152,7 @@ export function Features() {
             <section className={"py-20 md:py-24"}>
                 <div className={"container"}>
                     <h2 className={"text-5xl md:text-6xl font-medium text-center tracking-tighter"}>
-                        Discover the Power of ATLAS.
+                        Discover the Power of MAPGPT.
                     </h2>
                     <p className={"text-white/70 text-lg md:text-xl max-w-2xl mx-auto text-center tracking-tight mt-5"}>
                         ATLAS offers a comprehensive suite of tools to help you understand and visualize data about our world.

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -51,8 +51,8 @@ export function HeroSection() {
                 </motion.div>
                 {/* Hero Section Content Logic */}
                 <div className={"container relative mt-16"}>
-                    <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold italic bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center"}>atlas</h1>
-                    <p className={"text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center"}>ATLAS is a multi-agent Earth intelligence platform that provides real-time insights and analytics about our planet for exploration and automation.</p>
+                    <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold italic bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center"}>mapgpt</h1>
+                    <p className={"text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center"}>MAPGPT is a multi-agent Earth intelligence platform that provides real-time insights and analytics about our planet for exploration and automation.</p>
                     <div className={"flex justify-center mt-5"}>
                         <ActionButton label={"Get Started"} />
                     </div>

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -14,7 +14,7 @@ export default function SiteFooter() {
                         <div className={"border size-8 rounded-lg inline-flex items-center justify-center"}>
                             <SiteLogo className={"size-6 h-auto"}/>
                         </div>
-                        <p className={"font-medium"}>atlas</p>
+                        <p className={"font-medium"}>mapgpt</p>
                     </section>
 
                     <Link href="/privacy-terms" className="text-sm text-muted-foreground hover:underline">

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -37,7 +37,7 @@ export default function SiteHeader() {
                                         <div className={"border size-8 rounded-lg inline-flex items-center justify-center"}>
                                             <SiteLogo className={"size-6 h-auto"}/>
                                         </div>
-                                        <p className={"font-bold"}>QCX</p>
+                                        <p className={"font-bold"}>mapgpt</p>
                                     </div>
                                     <div className={"mt-8 mb-4"}>
                                         <nav className={"grid gap-4 items-center text-lg"}>


### PR DESCRIPTION
Replace all occurrences of "atlas" with "mapgpt" across various files.

* **package.json**
  - Replace "atlas-earth-intelligence" with "mapgpt-earth-intelligence" in the `name` field.

* **README.md**
  - Replace "ATLAS" with "MAPGPT" in the title and description.
  - Replace "ATLAS - AI-powered Earth Intelligence Platform" with "MAPGPT - AI-powered Earth Intelligence Platform".

* **src/app/layout.tsx**
  - Replace "ATLAS" with "MAPGPT" in the `title` and `description` fields of the `metadata` object.

* **src/components/features.tsx**
  - Replace "Discover the Power of ATLAS." with "Discover the Power of MAPGPT." in the `Features` component.

* **src/components/hero-section.tsx**
  - Replace "atlas" with "mapgpt" in the heading and description of the `HeroSection` component.

* **src/components/site-footer.tsx**
  - Replace "atlas" with "mapgpt" in the footer text.

* **src/components/site-header.tsx**
  - Replace "atlas" with "mapgpt" in the logo section.

