### PR TITLE
Update Privacy and Terms link to route to Tally form

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -17,13 +17,13 @@ export default function SiteFooter() {
                         <p className={"font-medium"}>atlas</p>
                     </section>
 
-                    <Link href="/privacy-terms" className="text-sm text-muted-foreground hover:underline">
+                    <Link href="https://tally.so/r/wADZ4o" className="text-sm text-muted-foreground hover:underline">
                         Privacy and Terms
                     </Link>
 
                     <p className="text-balance text-center text-sm leading-loose text-muted-foreground md:text-left">
                         ©️ 2024 QCX, All rights reserved. Built by <a
-                        href={"https://discord.gg/NqGY9EWjWj"}
+                        href={"https://discord.gg/NqGY9EWjW"}
                         target="_blank"
                         rel="noreferrer"
                         className="font-medium underline underline-offset-4"


### PR DESCRIPTION
Update the "Privacy and Terms" link in the footer to route to the new URL.

* Change the `href` attribute in the `Link` component in `src/components/site-footer.tsx` to `https://tally.so/r/wADZ4o`
