### PR TITLE
Replace all occurrences of mapgpt with QCX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MAPGPT - AI-powered Earth Intelligence Platform
+# QCX - AI-powered Earth Intelligence Platform
 
-MAPGPT is an Earth intelligence platform developed by QCX part of queuelab. It leverages advanced generative artificial intelligence technology to provide real-time insights and analytics about our planet. Whether you're an explorer, traveler or researcher MAPGPT offers a comprehensive suite of tools to help you explore, visualize and perform automation tasks. 
+QCX is an Earth intelligence platform developed by QCX part of queuelab. It leverages advanced generative artificial intelligence technology to provide real-time insights and analytics about our planet. Whether you're an explorer, traveler or researcher QCX offers a comprehensive suite of tools to help you explore, visualize and perform automation tasks. 
 
 ## Features
 
@@ -15,4 +15,4 @@ QCX is a leading technology company specializing in AI and machine learning solu
 
 ## GitHub Repository
 
-For more information, visit our [GitHub repository](https://github.com/queuelab/mapgpt).
+For more information, visit our [GitHub repository](https://github.com/queuelab/QCX).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mapgpt-earth-intelligence",
+  "name": "QCX-earth-intelligence",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,8 +8,8 @@ const inter = Inter({ subsets: ["latin"] });
 const roboto = Roboto({ subsets: ["latin"], weight: ["400", "700"] });
 
 export const metadata: Metadata = {
-  title: "MAPGPT",
-  description: "MAPGPT - AI-powered Earth intelligence platform by QCX",
+  title: "QCX",
+  description: "QCX - AI-powered Earth intelligence platform by QCX",
 };
 
 export default function RootLayout({children,}: Readonly<{ children: React.ReactNode; }>) {

--- a/src/components/github-indicator.tsx
+++ b/src/components/github-indicator.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export function GithubIndicator() {
     return (
         <>
-            <Link href={"https://github.com/queuelab/mapgpt"} target={"_blank"}
+            <Link href={"https://github.com/queuelab/QCX"} target={"_blank"}
                 className={"fixed bottom-6 right-6 z-50 size-12 border flex items-center justify-center rounded-full bg-black/70 hover:bg-muted transition"}>
                 <GitHubLogoIcon className={"size-6"}/>
             </Link>

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -51,8 +51,8 @@ export function HeroSection() {
                 </motion.div>
                 {/* Hero Section Content Logic */}
                 <div className={"container relative mt-16"}>
-                    <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold italic bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center"}>mapgpt</h1>
-                    <p className={"text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center"}>MAPGPT is a multi-agent Earth intelligence platform that provides real-time insights and analytics about our planet for exploration and automation.</p>
+                    <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold italic bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center"}>QCX</h1>
+                    <p className={"text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center"}>QCX is a multi-agent Earth intelligence platform that provides real-time insights and analytics about our planet for exploration and automation.</p>
                     <div className={"flex justify-center mt-5"}>
                         <ActionButton label={"Get Started"} href={"https://tally.so/r/wkWqkd"} />
                     </div>

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -14,7 +14,7 @@ export default function SiteFooter() {
                         <div className={"border size-8 rounded-lg inline-flex items-center justify-center"}>
                             <SiteLogo className={"size-6 h-auto"}/>
                         </div>
-                        <p className={"font-medium"}>mapgpt</p>
+                        <p className={"font-medium"}>QCX</p>
                     </section>
 
                     <Link href="https://tally.so/r/wADZ4o" className="text-sm text-muted-foreground hover:underline">

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -37,7 +37,7 @@ export default function SiteHeader() {
                                         <div className={"border size-8 rounded-lg inline-flex items-center justify-center"}>
                                             <SiteLogo className={"size-6 h-auto"}/>
                                         </div>
-                                        <p className={"font-bold"}>mapgpt</p>
+                                        <p className={"font-bold"}>QCX</p>
                                     </div>
                                     <div className={"mt-8 mb-4"}>
                                         <nav className={"grid gap-4 items-center text-lg"}>


### PR DESCRIPTION
Replace all occurrences of "mapgpt" with "QCX" across various files in the project.

* **package.json**
  - Change the project name from "mapgpt-earth-intelligence" to "QCX-earth-intelligence".

* **README.md**
  - Replace "MAPGPT" with "QCX" in the title and description.
  - Update the GitHub repository link to "https://github.com/queuelab/QCX".

* **src/app/layout.tsx**
  - Change the metadata title from "MAPGPT" to "QCX".
  - Update the metadata description to "QCX - AI-powered Earth intelligence platform by QCX".

* **src/components/github-indicator.tsx**
  - Update the GitHub link to "https://github.com/queuelab/QCX".

* **src/components/hero-section.tsx**
  - Replace the main heading "mapgpt" with "QCX".
  - Update the description mentioning "MAPGPT" to "QCX".

* **src/components/site-footer.tsx**
  - Change "mapgpt" to "QCX" in the logo section.

* **src/components/site-header.tsx**
  - Replace "mapgpt" with "QCX" in the logo section.

