### PR TITLE
Fix hero section layout

### DIFF
--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -51,9 +51,10 @@ export function HeroSection() {
                 </motion.div>
                 {/* Hero Section Content Logic */}
                 <div className={"container relative mt-16"}>
-                    <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center"}>QCX</h1>
+                    <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center mt-0"}>QCX</h1>
+                    <p className={"text-center text-sm md:text-base text-white/70 tracking-tight mt-2"}>Quality Computer Experience</p>
                     <p className={"text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center"}>QCX is a multi-agent Earth intelligence platform that provides real-time insights and analytics about our planet for exploration and automation.</p>
-                    <div className={"flex justify-center mt-5"}>
+                    <div className={"absolute bottom-0 left-1/2 transform -translate-x-1/2 mb-4"}>
                         <ActionButton label={"Get Started"} href={"https://tally.so/r/wkWqkd"} />
                     </div>
                 </div>


### PR DESCRIPTION
Update the hero section to adjust the positioning and content.

* Move the big QCX letters to the top central position.
* Add the phrase 'Quality Computer Experience' underneath QCX in a smaller size and different font.
* Place the 'Get Started' button at the bottom of the circle but inside.

