### PR TITLE
Increase logo speed in logo ticker

### DIFF
--- a/src/components/logo-ticker.tsx
+++ b/src/components/logo-ticker.tsx
@@ -40,7 +40,7 @@ export function LogoTicker() {
                       animate={{translateX: '0'}}
                       transition={{
                           repeat: Infinity,
-                          duration: isMobile ? 30 : 15,
+                          duration: isMobile ? 10 : 5,
                           ease: "linear",
                       }}
                       className={"flex flex-none gap-14 pr-14 -translate-x-1/2"}>


### PR DESCRIPTION
Update the speed of the logos in the `src/components/logo-ticker.tsx` file to be 3x faster.

* Change the `duration` property in the `transition` object within the `motion.div` component to 5 seconds for non-mobile devices.
* Change the `duration` property in the `transition` object within the `motion.div` component to 10 seconds for mobile devices.

