### PR TITLE
Fix nav bar links to navigate to the correct sections

### DIFF
--- a/src/components/call-to-action.tsx
+++ b/src/components/call-to-action.tsx
@@ -25,7 +25,7 @@ const useRelativeMousePosition = (to: RefObject<HTMLElement>) => {
     return [mouseX, mouseY];
 }
 
-export function CallToAction() {
+export function CallToAction({ id }: { id: string }) {
 
     const sectionRef = useRef<HTMLElement>(null);
     const borderedDivRef = useRef<HTMLDivElement>(null);
@@ -37,7 +37,7 @@ export function CallToAction() {
 
     return (
         <>
-            <section className={"py-20 md:py-24"} ref={sectionRef}>
+            <section className={"py-20 md:py-24"} ref={sectionRef} id={id}>
                 <div className={"container"}>
                     <motion.div
                         animate={{backgroundPositionX: BackgroundStars.width,}}

--- a/src/components/pricing-section.tsx
+++ b/src/components/pricing-section.tsx
@@ -19,9 +19,9 @@ const pricingTiers = [
   },
 ];
 
-export function PricingSection() {
+export function PricingSection({ id }: { id: string }) {
   return (
-    <section className="py-20 md:py-24">
+    <section className="py-20 md:py-24" id={id}>
       <div className="container">
         <h2 className="text-5xl md:text-6xl font-medium text-center tracking-tighter">
           Pricing Plans


### PR DESCRIPTION
Add `id` property to `PricingSection` and `CallToAction` component props.

* Modify `PricingSection` component in `src/components/pricing-section.tsx` to accept an `id` property and pass it to the root element.
* Modify `CallToAction` component in `src/components/call-to-action.tsx` to accept an `id` property and pass it to the root element.

