### PR TITLE
Fix missing id property in PricingSection component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ export default function Home() {
             <LogoTicker />
             <Features />
             <Testimonials />
-            <PricingSection />
+            <PricingSection id="pricing-section" />
             <CallToAction />
             <GithubIndicator />
             <SiteFooter />


### PR DESCRIPTION
Fix the missing 'id' property in the `PricingSection` component call in `src/app/page.tsx`.

* Add the `id` property to the `PricingSection` component call with the value "pricing-section" in `src/app/page.tsx` (line 19).

