### PR TITLE
Replace partner logos with new logos

### DIFF
--- a/src/components/logo-ticker.tsx
+++ b/src/components/logo-ticker.tsx
@@ -1,11 +1,9 @@
 "use client"
 
-import AcmeLogo from "@/assets/logo-acme.png";
-import ApexLogo from "@/assets/logo-apex.png";
-import QuantumLogo from "@/assets/logo-quantum.png";
-import CelestialLogo from "@/assets/logo-celestial.png";
-import PulseLogo from "@/assets/logo-pulse.png";
-import EchoLogo from "@/assets/logo-echo.png";
+import MsLogo from "@/assets/logo-ms.png";
+import GithubLogo from "@/assets/logo-github.png";
+import AwsLogo from "@/assets/logo-aws(1).png";
+import OpenAILogo from "@/assets/logo-openai.png";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
@@ -44,7 +42,7 @@ export function LogoTicker() {
                           ease: "linear",
                       }}
                       className={"flex flex-none gap-14 pr-14 -translate-x-1/2"}>
-                      {[AcmeLogo, ApexLogo, QuantumLogo, CelestialLogo, PulseLogo, EchoLogo, AcmeLogo, ApexLogo, QuantumLogo, CelestialLogo, PulseLogo, EchoLogo].map((logo, index) => (
+                      {[MsLogo, GithubLogo, AwsLogo, OpenAILogo, MsLogo, GithubLogo, AwsLogo, OpenAILogo].map((logo, index) => (
                           <Image src={logo} alt={`${logo}`} key={index} className={"h-6 w-auto"}/>
                       ))}
                   </motion.div>


### PR DESCRIPTION
### **User description**
Replace the current partner logos with new logos in `src/components/logo-ticker.tsx`.

* Import the new logos `logo-ms.png`, `logo-github.png`, `logo-aws.png`, and `logo-openai.png`.
* Replace the old logos with the new logos in the `LogoTicker` component.
* Ensure the new logos are displayed at the same size as the previous logos using the class `h-6 w-auto`.


___

### **PR Type**
enhancement


___

### **Description**
- Replaced the current partner logos with new logos in the `LogoTicker` component.
- Imported new logos: `logo-ms.png`, `logo-github.png`, `logo-aws.png`, and `logo-openai.png`.
- Ensured the new logos are displayed at the same size as the previous logos using the class `h-6 w-auto`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logo-ticker.tsx</strong><dd><code>Update partner logos in LogoTicker component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/logo-ticker.tsx

<li>Replaced old partner logos with new logos.<br> <li> Imported new logo images: <code>logo-ms.png</code>, <code>logo-github.png</code>, <code>logo-aws.png</code>, <br><code>logo-openai.png</code>.<br> <li> Updated the <code>LogoTicker</code> component to use new logos.<br> <li> Ensured consistent logo display size with class <code>h-6 w-auto</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/queuelab.github.io/pull/46/files#diff-2789d14beb0ae0551ff0b2064a976ec234a497a97860e5aad0aec38afb8e195c">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information