### PR TITLE
Fix hero section to ensure text alignment and color

### DIFF
--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -52,8 +52,10 @@ export function HeroSection() {
                 {/* Hero Section Content Logic */}
                 <div className={"container relative mt-16"}>
                     <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center"}>QCX</h1>
-                    <p className={"text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center italic text-sm"}>Your earthly companion, earthing with you all the time for your</p>
-                    <p className={"text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center font-handwriting text-sm tracking-wider"}>QUALITY COMPUTER EXPERIENCE</p>
+                    <p className={"font-handwriting text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center italic text-sm"}>
+                        Your earthly companion, for your
+                        <span className={"font-handwriting text-sm tracking-wider text-[#7CFC00]"}> QUALITY COMPUTER EXPERIENCE</span>
+                    </p>
                     <div className={"flex justify-center mt-5"}>
                         <ActionButton label={"Get Started"} href={"https://tally.so/r/wkWqkd"} />
                     </div>

--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -52,7 +52,6 @@ export function HeroSection() {
                 {/* Hero Section Content Logic */}
                 <div className={"container relative mt-16"}>
                     <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center"}>QCX</h1>
-                    <p className={"font-handwriting text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center italic text-sm"}>
                         Your earthly companion, for your
                         <span className={"font-handwriting text-sm tracking-wider text-[#7CFC00]"}> QUALITY COMPUTER EXPERIENCE</span>
                     </p>


### PR DESCRIPTION
### **User description**
Combine the earthing sentence and "QUALITY COMPUTER EXPERIENCE" text into a single `<p>` tag.

* Style the combined text with `italic text-sm` for the earthing sentence and `font-handwriting text-sm tracking-wider` for "QUALITY COMPUTER EXPERIENCE"
* Change the color of "QUALITY COMPUTER EXPERIENCE" to match the color of "our trusted partners"


___

### **PR Type**
enhancement


___

### **Description**
- Combined the earthing sentence and "QUALITY COMPUTER EXPERIENCE" into a single `<p>` tag for improved alignment.
- Applied styling to the combined text, including `italic text-sm` for the earthing sentence and `font-handwriting text-sm tracking-wider` for "QUALITY COMPUTER EXPERIENCE".
- Updated the color of "QUALITY COMPUTER EXPERIENCE" to ensure consistency with "our trusted partners".



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hero-section.tsx</strong><dd><code>Improve text alignment and styling in hero section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/hero-section.tsx

<li>Combined two <code><p></code> tags into one for better text alignment.<br> <li> Styled the combined text with <code>italic text-sm</code> and <code>font-handwriting </code><br><code>text-sm tracking-wider</code>.<br> <li> Changed the color of "QUALITY COMPUTER EXPERIENCE" to match "our <br>trusted partners".<br>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/queuelab.github.io/pull/56/files#diff-b95f92269d9c18e7cb200c220798f0649bde336578faf7bda3218ec4c0bced69">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information