### PR TITLE
Fix feature buttons requiring double click to render product previews

### DIFF
--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -155,6 +155,7 @@ export function Features({ id }: { id: string }) {
       animateOptions
     );
     currentImage.set(tabs[index].image);
+    setSelectedImage(tabs[index].image.src); // P8220
   };
 
   const handleImageClick = (image: string) => {


### PR DESCRIPTION
### **User description**
Fix the issue where feature buttons require two clicks to render product previews.

* Update the `handleSelectTab` function to immediately update the image when a tab is selected.
* Set the `selectedImage` state to the new image source upon tab selection.


___

### **PR Type**
bug_fix


___

### **Description**
- Fixed the issue where feature buttons required two clicks to render product previews.
- Updated the `handleSelectTab` function to immediately update the `selectedImage` state with the new image source upon tab selection.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>features.tsx</strong><dd><code>Fix double-click issue for feature buttons in `features.tsx`</code></dd></summary>
<hr>

src/components/features.tsx

<li>Updated <code>handleSelectTab</code> function to set <code>selectedImage</code> state <br>immediately.<br> <li> Ensured image updates on tab selection to fix double-click issue.<br>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/queuelab.github.io/pull/57/files#diff-dca46287ff268435b7b3c3625cc97a903a6997f2d726c9cf25a891308ee17bad">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information