### PR TITLE
Update Careers nav bar to link to Get Started section

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -23,7 +23,7 @@ export default function SiteHeader() {
                             <nav className={"flex gap-8 items-center text-sm"}>
                                 <Link href={"#features"} className={"text-white/70 hover:text-white transition"}>Features</Link>
                                 <Link href={"#pricing"} className={"text-white/70 hover:text-white transition"}>Pricing</Link>
-                                <Link href={"#open-core"} className={"text-white/70 hover:text-white transition"}>Careers</Link>
+                                <Link href={"#careers"} className={"text-white/70 hover:text-white transition"}>Careers</Link>
                             </nav>
                         </section>
                         <section className={"flex max-md:gap-4 items-center"}>
@@ -49,9 +49,9 @@ export default function SiteHeader() {
                                                 <Wallet2 className={"size-6"} />
                                                 Pricing
                                             </Link>
-                                            <Link href={"#open-core"} className={"flex items-center gap-3 text-white/70 hover:text-white transition"}>
+                                            <Link href={"#careers"} className={"flex items-center gap-3 text-white/70 hover:text-white transition"}>
                                                 <Newspaper className={"size-6"} />
-                                                Open Core
+                                                Careers
                                             </Link>
                                         </nav>
                                     </div>


### PR DESCRIPTION
### **User description**
Update the careers nav bar link and rename "Open Core" to "Careers".

* Change the `Link` component in the navigation bar to link to `#careers` instead of `#open-core`.
* Change the text "Open Core" to "Careers" in the navigation bar.


___

### **PR Type**
enhancement


___

### **Description**
- Updated the navigation bar to link to the Careers section instead of Open Core.
- Changed the text label from "Open Core" to "Careers" in the navigation bar.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>site-header.tsx</strong><dd><code>Update navigation bar links and text for Careers section</code>&nbsp; </dd></summary>
<hr>

src/components/site-header.tsx

<li>Updated the <code>Link</code> component in the navigation bar to link to <code>#careers</code> <br>instead of <code>#open-core</code>.<br> <li> Changed the text from "Open Core" to "Careers" in the navigation bar.<br>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/queuelab.github.io/pull/60/files#diff-3de2e2ca7d47ee39efc8499eb66f3b4d4d2a73eb47edb53752f099bce158b59e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information