### PR TITLE
Replace resolution search with product-gif and add gif player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ia-saas-landing",
+  "name": "QCX-earth-intelligence",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ia-saas-landing",
+      "name": "QCX-earth-intelligence",
       "version": "0.1.0",
       "dependencies": {
         "@dotlottie/react-player": "^1.6.19",

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -9,6 +9,8 @@ import productImage3 from "@/assets/product-image-3.png";
 import productImage4 from "@/assets/product-image-4.png";
 import productImage5 from "@/assets/product-image-5.png";
 import productImage2 from "@/assets/product-image-2.png";
+import gifPreview from "@/assets/product-gif.gif"; // P8220
+import { GifPlayer } from "react-gif-player"; // P3b95
 
 const tabs = [
   {
@@ -18,7 +20,7 @@ const tabs = [
     backgroundPositionX: 50,
     backgroundPositionY: 50,
     backgroundSizeX: 100,
-    image: productImage1,
+    image: gifPreview, // P8220
   },
   {
     icon: "/assets/lottie/click.lottie",
@@ -186,17 +188,21 @@ export function Features({ id }: { id: string }) {
           </div>
           <motion.div className="border border-muted rounded-xl p-2.5 mt-3">
             <div className="relative aspect-video rounded-lg overflow-hidden">
-              <Image
-                src={currentImage.get().src} // Fix: Use `.src` here
-                alt={tabs[selectedTab].title}
-                fill
-                className="object-contain"
-                onClick={() => handleImageClick(currentImage.get().src)} // Fix: Use `.src` here
-                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 70vw"
-                priority
-                quality={100}
-                onError={handleImageError}
-              />
+              {selectedTab === 0 ? ( // P3b95
+                <GifPlayer gif={gifPreview.src} autoplay /> // P3b95
+              ) : ( // P3b95
+                <Image
+                  src={currentImage.get().src} // Fix: Use `.src` here
+                  alt={tabs[selectedTab].title}
+                  fill
+                  className="object-contain"
+                  onClick={() => handleImageClick(currentImage.get().src)} // Fix: Use `.src` here
+                  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 70vw"
+                  priority
+                  quality={100}
+                  onError={handleImageError}
+                />
+              )}
             </div>
           </motion.div>
         </div>


### PR DESCRIPTION
### **User description**
the operation was cancelled


___

### **PR Type**
enhancement, dependencies


___

### **Description**
- Integrated a GIF player for the "Resolution Search" tab using `react-gif-player`, replacing the static image with a GIF preview.
- Implemented conditional rendering to display either a GIF or an image based on the selected tab.
- Updated the project name in the `package-lock.json` file to "QCX-earth-intelligence".



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>features.tsx</strong><dd><code>Integrate GIF player for Resolution Search tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/features.tsx

<li>Added a GIF player for the first tab using <code>react-gif-player</code>.<br> <li> Replaced static image with GIF preview for the "Resolution Search" <br>tab.<br> <li> Conditional rendering of GIF or image based on selected tab.<br>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/queuelab.github.io/pull/62/files#diff-dca46287ff268435b7b3c3625cc97a903a6997f2d726c9cf25a891308ee17bad">+18/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package-lock.json</strong><dd><code>Update project name in package metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package-lock.json

- Updated project name in package metadata.



</details>


  </td>
  <td><a href="https://github.com/QueueLab/queuelab.github.io/pull/62/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information