### PR TITLE
Animate italic text on landing page

### DIFF
--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -52,7 +52,14 @@ export function HeroSection() {
                 {/* Hero Section Content Logic */}
                 <div className={"container relative mt-16"}>
                     <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center"}>QCX</h1>
-                    <p className={"font-handwriting text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center italic flex justify-center"}>is a multi-agent earth intelligence platform for exploration and automation. Your earthly companion, earthing for your</p> 
+                    <motion.p 
+                        className={"font-handwriting text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center italic flex justify-center"}
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        transition={{ duration: 2 }}
+                    >
+                        is a multi-agent earth intelligence platform for exploration and automation. Your earthly companion, earthing for your
+                    </motion.p>
                     <span className={"text-sm tracking-wider text-[#7CFC00] flex justify-center"}>QUALITY COMPUTER EXPERIENCE </span>
                     <div className={"flex justify-center mt-5"}>
                         <ActionButton label={"Get Started"} href={"https://tally.so/r/wkWqkd"} />


### PR DESCRIPTION
Add fading animation to italic text on the landing page.

* Import `motion` from `framer-motion`.
* Wrap the italic text in a `motion.p` component.
* Set initial opacity to 0 and animate to opacity 1 with a duration of 2 seconds.

