### PR TITLE
Add open graph image to metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,9 @@ const roboto = Roboto({ subsets: ["latin"], weight: ["400", "700"] });
 export const metadata: Metadata = {
   title: "QCX",
   description: "QCX - AI-powered Location Intelligence platform by QCX",
+  openGraph: {
+    images: ["/src/app/icon.png"]
+  }
 };
 
 export default function RootLayout({children,}: Readonly<{ children: React.ReactNode; }>) {


### PR DESCRIPTION
### **User description**
Add open graph image to metadata in `src/app/layout.tsx`.

* Add `openGraph` property to `metadata` object with `images` array containing the path to the open graph image.


___

### **PR Type**
Enhancement


___

### **Description**
* Added OpenGraph metadata configuration to the root layout to improve social media sharing
* Configured image property to use "/src/app/icon.png" for social media previews
* Enhanced SEO and social sharing capabilities by providing proper OpenGraph metadata



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Add OpenGraph image metadata for social sharing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/layout.tsx

<li>Added OpenGraph metadata configuration to include an image path<br> <li> Image path points to "/src/app/icon.png"<br>


</details>


  </td>
  <td><a href="https://github.com/QueueLab/queuelab.github.io/pull/72/files#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information